### PR TITLE
Add `current-state` helper for debugging, returns reactive entity as map

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "shadow-cljs": "2.11.15"
   },
   "scripts": {
-    "test": "shadow-cljs compile test"
+    "test": "shadow-cljs -A:test compile test"
   },
   "name": "reactive-entity",
   "version": "0.1.0",


### PR DESCRIPTION
Calling `current-state` gives you a map of the current attrs on the
backing DataScript entity. This is useful for debugging during Reagent
render passes where you don't want to subscribe to all attribute changes
but you might want to log what the entity looks like to the console.

Doesn't recurse into ref attributes.